### PR TITLE
feat: implement tools archive page with card layout and admin settings

### DIFF
--- a/admin/class-taskip-admin.php
+++ b/admin/class-taskip-admin.php
@@ -275,11 +275,20 @@ class Taskip_Admin
     {
         register_setting('taskip_templates_settings', 'taskip_fluentcrm_username');
         register_setting('taskip_templates_settings', 'taskip_fluentcrm_password');
+        register_setting('taskip_templates_settings', 'taskip_tools_archive_title');
+        register_setting('taskip_templates_settings', 'taskip_tools_archive_paragraph');
 
         add_settings_section(
             'taskip_fluentcrm_section',
             __('Fluent CRM API Settings', 'taskip-templates'),
             array($this, 'fluentcrm_section_callback'),
+            'taskip_templates_settings'
+        );
+
+        add_settings_section(
+            'taskip_tools_archive_section',
+            __('Tools Archive Settings', 'taskip-templates'),
+            array($this, 'tools_archive_section_callback'),
             'taskip_templates_settings'
         );
 
@@ -297,6 +306,22 @@ class Taskip_Admin
             array($this, 'fluentcrm_password_callback'),
             'taskip_templates_settings',
             'taskip_fluentcrm_section'
+        );
+
+        add_settings_field(
+            'taskip_tools_archive_title',
+            __('Tools Archive Title', 'taskip-templates'),
+            array($this, 'tools_archive_title_callback'),
+            'taskip_templates_settings',
+            'taskip_tools_archive_section'
+        );
+
+        add_settings_field(
+            'taskip_tools_archive_paragraph',
+            __('Tools Archive Description', 'taskip-templates'),
+            array($this, 'tools_archive_paragraph_callback'),
+            'taskip_templates_settings',
+            'taskip_tools_archive_section'
         );
     }
 
@@ -324,5 +349,33 @@ class Taskip_Admin
     {
         $password = get_option('taskip_fluentcrm_password');
         echo '<input type="password" name="taskip_fluentcrm_password" value="' . esc_attr($password) . '" class="regular-text">';
+    }
+
+    /**
+     * Tools archive section description
+     */
+    public function tools_archive_section_callback()
+    {
+        echo '<p>' . esc_html__('Configure the title and description for your tools archive page.', 'taskip-templates') . '</p>';
+    }
+
+    /**
+     * Tools archive title field callback
+     */
+    public function tools_archive_title_callback()
+    {
+        $title = get_option('taskip_tools_archive_title', 'Free Tools Collection');
+        echo '<input type="text" name="taskip_tools_archive_title" value="' . esc_attr($title) . '" class="regular-text">';
+        echo '<p class="description">' . esc_html__('Enter the main title for your tools archive page.', 'taskip-templates') . '</p>';
+    }
+
+    /**
+     * Tools archive paragraph field callback
+     */
+    public function tools_archive_paragraph_callback()
+    {
+        $paragraph = get_option('taskip_tools_archive_paragraph', 'Discover our collection of free online tools designed to help you work smarter and faster. From generators to converters, find the perfect tool for your needs.');
+        echo '<textarea name="taskip_tools_archive_paragraph" rows="4" class="large-text">' . esc_textarea($paragraph) . '</textarea>';
+        echo '<p class="description">' . esc_html__('Enter the description paragraph that appears below the title.', 'taskip-templates') . '</p>';
     }
 }

--- a/assets/css/taskip-templates.css
+++ b/assets/css/taskip-templates.css
@@ -1249,3 +1249,207 @@
     opacity: 0.6;
     pointer-events: none;
 }
+
+/* Tools Archive Styles */
+.taskip-tools-archive {
+    padding-top: 30px;
+    padding-bottom: 80px;
+}
+
+.taskip-tools-header {
+    text-align: center;
+    margin: 0 auto;
+}
+
+.taskip-tools-header .taskip-second-heading-three {
+    max-width: 850px;
+}
+
+.taskip-tools-header .template-section-para {
+    max-width: 760px;
+    margin: 0 auto;
+    margin-top: 20px;
+    line-height: 1.5;
+    font-weight: 500;
+}
+
+.taskip-tools-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+/* Tool Card Styles */
+.ib-tool-card {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.ib-tool-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+}
+
+.ib-tool-header {
+    padding: 2rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #ffffff;
+}
+
+.ib-tool-name {
+    margin: 0 0 1rem 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1.3;
+    color: #ffffff !important;
+}
+
+.ib-tool-tagline {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.5;
+    opacity: 0.95;
+    color: #ffffff !important;
+}
+
+.ib-tool-body {
+    padding: 2rem;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.ib-tool-description {
+    margin: 0 0 1.5rem 0;
+    font-size: 1rem;
+    line-height: 1.6;
+    color: #666;
+    flex-grow: 1;
+}
+
+.ib-tool-features {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 2rem 0;
+}
+
+.ib-tool-features li {
+    position: relative;
+    padding-left: 1.5rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.95rem;
+    line-height: 1.4;
+    color: #555;
+}
+
+.ib-tool-features li:before {
+    content: "✓";
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: #00b289;
+    font-weight: bold;
+    font-size: 1rem;
+}
+
+.ib-tool-cta {
+    margin-top: auto;
+    padding-top: 1rem;
+    border-top: 1px solid #f0f0f0;
+}
+
+.ib-tool-cta a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.875rem 1.5rem;
+    background: rgba(102, 126, 234, 0.1);
+    color: #667eea;
+    text-decoration: none;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+    width: 100%;
+    text-align: center;
+}
+
+.ib-tool-cta a:hover {
+    background: #667eea;
+    color: #ffffff;
+    transform: translateY(-1px);
+}
+
+.ib-tool-cta a span {
+    display: inline-block;
+}
+
+/* Tools Pagination */
+.taskip-tools-pagination {
+    margin-top: 3rem;
+    text-align: center;
+}
+
+/* No Tools Message */
+.taskip-no-tools {
+    text-align: center;
+    padding: 3rem 2rem;
+    color: #666;
+    font-size: 1.1rem;
+    background: #f9f9f9;
+    border-radius: 12px;
+    grid-column: 1 / -1;
+}
+
+/* Responsive Styles for Tools */
+@media (max-width: 768px) {
+    .taskip-tools-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+    
+    .ib-tool-header {
+        padding: 1.5rem;
+    }
+    
+    .ib-tool-name {
+        font-size: 1.3rem;
+    }
+    
+    .ib-tool-tagline {
+        font-size: 0.9rem;
+    }
+    
+    .ib-tool-body {
+        padding: 1.5rem;
+    }
+    
+    .taskip-tools-header {
+        margin-top: 80px;
+    }
+}
+
+@media (max-width: 480px) {
+    .taskip-tools-grid {
+        gap: 1rem;
+    }
+    
+    .ib-tool-header {
+        padding: 1.25rem;
+    }
+    
+    .ib-tool-name {
+        font-size: 1.2rem;
+    }
+    
+    .ib-tool-body {
+        padding: 1.25rem;
+    }
+}

--- a/includes/class-taskip-metaboxes.php
+++ b/includes/class-taskip-metaboxes.php
@@ -28,6 +28,7 @@ class Taskip_Metaboxes {
         // Add meta boxes for template metadata
         add_action('add_meta_boxes', array($this, 'add_template_meta_boxes'));
         add_action('add_meta_boxes', array($this, 'add_usecases_meta_boxes'));
+        add_action('add_meta_boxes', array($this, 'add_tools_meta_boxes'));
 
         // Save template metadata
         add_action('save_post', array($this, 'save_template_meta'));
@@ -59,6 +60,20 @@ class Taskip_Metaboxes {
         );
     }
 
+    /**
+     * Add meta boxes for tools metadata
+     */
+    public function add_tools_meta_boxes() {
+        add_meta_box(
+            'taskip_tools_meta',
+            __('Tool Details', 'taskip-templates'),
+            array($this, 'render_tools_meta_box'),
+            'tools',
+            'normal',
+            'high'
+        );
+    }
+
 
     /**
      * Render usecases meta box
@@ -83,6 +98,74 @@ class Taskip_Metaboxes {
                 <label for="taskip_usecase_description"><?php _e('Description:', 'taskip-templates'); ?></label>
                 <textarea id="taskip_usecase_description" name="taskip_usecase_description" class="widefat" rows="5"><?php echo esc_textarea($description); ?></textarea>
                 <span class="description"><?php _e('Detailed description of the use case', 'taskip-templates'); ?></span>
+            </div>
+        </div>
+        <?php
+    }
+
+    /**
+     * Render tools meta box
+     *
+     * @param WP_Post $post The post object.
+     */
+    public function render_tools_meta_box($post) {
+        // Add nonce for security
+        wp_nonce_field('taskip_tools_meta', 'taskip_tools_meta_nonce');
+
+        // Get saved metadata
+        $card_title = get_post_meta($post->ID, '_taskip_tool_card_title', true);
+        $tagline = get_post_meta($post->ID, '_taskip_tool_tagline', true);
+        $description = get_post_meta($post->ID, '_taskip_tool_description', true);
+        $features = get_post_meta($post->ID, '_taskip_tool_features', true);
+        $cta_url = get_post_meta($post->ID, '_taskip_tool_cta_url', true);
+        $gradient_start = get_post_meta($post->ID, '_taskip_tool_gradient_start', true);
+        $gradient_end = get_post_meta($post->ID, '_taskip_tool_gradient_end', true);
+        
+        // Set defaults
+        $gradient_start = !empty($gradient_start) ? $gradient_start : '#667eea';
+        $gradient_end = !empty($gradient_end) ? $gradient_end : '#764ba2';
+        ?>
+        <div class="taskip-meta-section">
+            <div class="taskip-meta-field">
+                <label for="taskip_tool_card_title"><?php _e('Card Title (Optional):', 'taskip-templates'); ?></label>
+                <input type="text" id="taskip_tool_card_title" name="_taskip_tool_card_title" value="<?php echo esc_attr($card_title); ?>" class="widefat" />
+                <span class="description"><?php _e('Custom title for archive page card. Leave empty to use default post title.', 'taskip-templates'); ?></span>
+            </div>
+            
+            <div class="taskip-meta-field">
+                <label for="taskip_tool_tagline"><?php _e('Tool Tagline:', 'taskip-templates'); ?></label>
+                <input type="text" id="taskip_tool_tagline" name="_taskip_tool_tagline" value="<?php echo esc_attr($tagline); ?>" class="widefat" />
+                <span class="description"><?php _e('Short tagline for the tool (displayed in header)', 'taskip-templates'); ?></span>
+            </div>
+            
+            <div class="taskip-meta-field">
+                <label for="taskip_tool_description"><?php _e('Tool Description:', 'taskip-templates'); ?></label>
+                <textarea id="taskip_tool_description" name="_taskip_tool_description" class="widefat" rows="3"><?php echo esc_textarea($description); ?></textarea>
+                <span class="description"><?php _e('Brief description of the tool (displayed in body)', 'taskip-templates'); ?></span>
+            </div>
+            
+            <div class="taskip-meta-field">
+                <label for="taskip_tool_features"><?php _e('Tool Features:', 'taskip-templates'); ?></label>
+                <textarea id="taskip_tool_features" name="_taskip_tool_features" class="widefat" rows="5"><?php echo esc_textarea($features); ?></textarea>
+                <span class="description"><?php _e('List of tool features (one per line)', 'taskip-templates'); ?></span>
+            </div>
+            
+            <div class="taskip-meta-field">
+                <label for="taskip_tool_cta_url"><?php _e('CTA URL:', 'taskip-templates'); ?></label>
+                <input type="url" id="taskip_tool_cta_url" name="_taskip_tool_cta_url" value="<?php echo esc_url($cta_url); ?>" class="widefat" />
+                <span class="description"><?php _e('URL for the "Try [Tool Name]" button', 'taskip-templates'); ?></span>
+            </div>
+            
+            <div class="taskip-meta-field">
+                <label for="taskip_tool_gradient_start"><?php _e('Header Gradient Start Color:', 'taskip-templates'); ?></label>
+                <input type="color" id="taskip_tool_gradient_start" name="_taskip_tool_gradient_start" value="<?php echo esc_attr($gradient_start); ?>" />
+                <span class="description"><?php _e('Starting color for the header gradient', 'taskip-templates'); ?></span>
+            </div>
+            
+            <div class="taskip-meta-field">
+                <label for="taskip_tool_gradient_end"><?php _e('Header Gradient End Color:', 'taskip-templates'); ?></label>
+                <input type="color" id="taskip_tool_gradient_end" name="_taskip_tool_gradient_end" value="<?php echo esc_attr($gradient_end); ?>" />
+                <span class="description"><?php _e('Ending color for the header gradient', 'taskip-templates'); ?></span>
             </div>
         </div>
         <?php
@@ -128,13 +211,17 @@ Used by 250+ professionals";
      */
     public function save_template_meta($post_id) {
 
-        // Add nonce check for usecases
+        // Add nonce check for usecases, templates, and tools
         if (isset($_POST['taskip_usecases_meta_nonce'])) {
             if (!wp_verify_nonce($_POST['taskip_usecases_meta_nonce'], 'taskip_usecases_meta')) {
                 return;
             }
         } elseif (isset($_POST['taskip_template_meta_nonce'])) {
             if (!wp_verify_nonce($_POST['taskip_template_meta_nonce'], 'taskip_template_meta')) {
+                return;
+            }
+        } elseif (isset($_POST['taskip_tools_meta_nonce'])) {
+            if (!wp_verify_nonce($_POST['taskip_tools_meta_nonce'], 'taskip_tools_meta')) {
                 return;
             }
         } else {
@@ -174,6 +261,33 @@ Used by 250+ professionals";
             }
             if (isset($_POST['taskip_usecase_description'])) {
                 update_post_meta($post_id, '_taskip_usecase_description', sanitize_textarea_field($_POST['taskip_usecase_description']));
+            }
+        } elseif ($_POST['post_type'] === 'tools') {
+            if (!current_user_can('edit_post', $post_id)) {
+                return;
+            }
+
+            // Save tools metadata
+            if (isset($_POST['_taskip_tool_card_title'])) {
+                update_post_meta($post_id, '_taskip_tool_card_title', sanitize_text_field($_POST['_taskip_tool_card_title']));
+            }
+            if (isset($_POST['_taskip_tool_tagline'])) {
+                update_post_meta($post_id, '_taskip_tool_tagline', sanitize_text_field($_POST['_taskip_tool_tagline']));
+            }
+            if (isset($_POST['_taskip_tool_description'])) {
+                update_post_meta($post_id, '_taskip_tool_description', sanitize_textarea_field($_POST['_taskip_tool_description']));
+            }
+            if (isset($_POST['_taskip_tool_features'])) {
+                update_post_meta($post_id, '_taskip_tool_features', sanitize_textarea_field($_POST['_taskip_tool_features']));
+            }
+            if (isset($_POST['_taskip_tool_cta_url'])) {
+                update_post_meta($post_id, '_taskip_tool_cta_url', esc_url_raw($_POST['_taskip_tool_cta_url']));
+            }
+            if (isset($_POST['_taskip_tool_gradient_start'])) {
+                update_post_meta($post_id, '_taskip_tool_gradient_start', sanitize_hex_color($_POST['_taskip_tool_gradient_start']));
+            }
+            if (isset($_POST['_taskip_tool_gradient_end'])) {
+                update_post_meta($post_id, '_taskip_tool_gradient_end', sanitize_hex_color($_POST['_taskip_tool_gradient_end']));
             }
         }
 

--- a/includes/class-taskip-templates.php
+++ b/includes/class-taskip-templates.php
@@ -67,7 +67,9 @@ class Taskip_Templates {
 
         // Only enqueue on template pages
         if (is_post_type_archive('taskip_template') ||
+            is_post_type_archive('tools') ||
             is_singular('taskip_template') ||
+            is_singular('tools') ||
             is_tax('template_type') ||
             is_tax('template_industry') ||
             is_page_template('templates/page-templates.php')) {
@@ -194,6 +196,8 @@ class Taskip_Templates {
             $file = 'single-tools.php';
         } elseif (is_post_type_archive('taskip_template')) {
             $file = 'archive-taskip_template.php';
+        } elseif (is_post_type_archive('tools')) {
+            $file = 'archive-tools.php';
         } elseif (is_tax('template_type') || is_tax('template_industry')) {
             $file = 'taxonomy-template.php';
         }

--- a/templates/archive-tools.php
+++ b/templates/archive-tools.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * The template for displaying tools archives
+ *
+ * @package Taskip Templates Showcase
+ */
+
+get_header(); ?>
+
+<div class="taskip-tools-archive">
+    <div class="container">
+        <header class="taskip-tools-header">
+            <div class="taskip taskip-inter taskip-pricing pt-120 pb-120">
+                <div class="col-md-12">
+                    <?php
+                    // Get archive page settings
+                    $archive_title = get_option('taskip_tools_archive_title', 'Free Tools Collection');
+                    $archive_paragraph = get_option('taskip_tools_archive_paragraph', 'Discover our collection of free online tools designed to help you work smarter and faster. From generators to converters, find the perfect tool for your needs.');
+                    ?>
+                    <div class="subtitle-two"><?php echo esc_html__('Taskip Free Tools','taskip-templates')?></div>
+                    <h1 class="taskip-second-heading-three text-center"><?php echo esc_html($archive_title); ?></h1>
+                    <p class="template-section-para"><?php echo esc_html($archive_paragraph); ?></p>
+                </div>
+            </div>
+        </header>
+
+        <div class="taskip-tools-grid">
+            <?php if (have_posts()) : ?>
+                <?php while (have_posts()) : the_post(); 
+                    // Get tool metadata
+                    $card_title = get_post_meta(get_the_ID(), '_taskip_tool_card_title', true);
+                    $tagline = get_post_meta(get_the_ID(), '_taskip_tool_tagline', true);
+                    $description = get_post_meta(get_the_ID(), '_taskip_tool_description', true);
+                    $features = get_post_meta(get_the_ID(), '_taskip_tool_features', true);
+                    $cta_url = get_post_meta(get_the_ID(), '_taskip_tool_cta_url', true);
+                    $gradient_start = get_post_meta(get_the_ID(), '_taskip_tool_gradient_start', true);
+                    $gradient_end = get_post_meta(get_the_ID(), '_taskip_tool_gradient_end', true);
+                    
+                    // Set defaults and fallbacks
+                    $display_title = !empty($card_title) ? $card_title : get_the_title();
+                    $gradient_start = !empty($gradient_start) ? $gradient_start : '#667eea';
+                    $gradient_end = !empty($gradient_end) ? $gradient_end : '#764ba2';
+                    $tagline = !empty($tagline) ? $tagline : get_the_excerpt();
+                    $description = !empty($description) ? $description : 'A helpful tool for your daily tasks.';
+                    $cta_url = !empty($cta_url) ? $cta_url : get_permalink();
+                    
+                    // Process features into array
+                    $features_array = array();
+                    if (!empty($features)) {
+                        $features_array = array_filter(array_map('trim', explode("\n", $features)));
+                    }
+                ?>
+                    <div class="ib-tool-card">
+                        <div class="ib-tool-header" style="background:linear-gradient(135deg, <?php echo esc_attr($gradient_start); ?> 0%, <?php echo esc_attr($gradient_end); ?> 100%);color:#ffffff">
+                            <h3 class="ib-tool-name" style="color:#ffffff"><?php echo esc_html($display_title); ?></h3>
+                            <?php if ($tagline) : ?>
+                                <p class="ib-tool-tagline" style="color:#ffffff"><?php echo esc_html($tagline); ?></p>
+                            <?php endif; ?>
+                        </div>
+                        <div class="ib-tool-body">
+                            <?php if ($description) : ?>
+                                <p class="ib-tool-description"><?php echo esc_html($description); ?></p>
+                            <?php endif; ?>
+                            
+                            <?php if (!empty($features_array)) : ?>
+                                <ul class="ib-tool-features">
+                                    <?php foreach ($features_array as $feature) : ?>
+                                        <li><?php echo esc_html($feature); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php endif; ?>
+                            
+                            <div class="ib-tool-cta">
+                                <a href="<?php echo esc_url($cta_url); ?>" style="color:<?php echo esc_attr($gradient_start); ?>" target="_blank" rel="noopener">
+                                    <span>Try <?php echo esc_html($display_title); ?></span>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                <?php endwhile; ?>
+            <?php else : ?>
+                <p class="taskip-no-tools"><?php _e("No tools found.", "taskip-templates"); ?></p>
+            <?php endif; ?>
+        </div>
+        
+        <div class="taskip-tools-pagination">
+            <div class="blog-pagination-wraper">
+                <?php 
+                // Check if Taskip() function exists, otherwise use default WordPress pagination
+                if (function_exists('Taskip')) {
+                    Taskip()->post_pagination();
+                } else {
+                    the_posts_pagination();
+                }
+                ?>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
- Add comprehensive meta fields for tools post type:
  * Custom card title (optional override for archive display)
  * Tool tagline for header description
  * Tool description for main body content
  * Tool features list (bulleted format)
  * CTA URL for "Try Tool" button
  * Gradient colors (start & end) for header background

- Create tools archive template (archive-tools.php):
  * Professional card layout with gradient headers
  * Responsive grid design
  * Dynamic content from meta fields
  * Fallback to default values when meta fields empty

- Add comprehensive CSS styling:
  * Card hover effects and animations
  * Responsive breakpoints for mobile/tablet
  * Professional typography and spacing
  * Custom gradient backgrounds per tool

- Implement admin settings for tools archive page:
  * Configurable archive page title
  * Configurable archive page description
  * Settings available in Templates → Settings

- Update template loader to support tools archive
- Enhance script/style enqueuing for tools pages
