### PR TITLE
feat: implement legal pages post type with hero sections and archive

### DIFF
--- a/assets/css/taskip-templates.css
+++ b/assets/css/taskip-templates.css
@@ -1457,3 +1457,659 @@
         padding: 1.25rem;
     }
 }
+
+/* Legal Pages Styles */
+
+/* Legal Archive Page */
+.taskip-legal-archive {
+    padding: 3rem 0;
+    padding-top: 140px;
+    background: #f8f9fa;
+    min-height: calc(100vh - 120px);
+}
+
+.taskip-legal-archive-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.taskip-legal-archive-header {
+    text-align: center;
+    margin-bottom: 3rem;
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.taskip-legal-archive-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin-bottom: 1rem;
+    line-height: 1.2;
+}
+
+.taskip-legal-archive-description {
+    font-size: 1.125rem;
+    color: #666;
+    line-height: 1.6;
+    margin: 0;
+}
+
+.taskip-legal-archive-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+    margin-bottom: 3rem;
+}
+
+.taskip-legal-archive-item {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.taskip-legal-archive-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.12);
+}
+
+.taskip-legal-card {
+    padding: 2rem;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.taskip-legal-card-icon {
+    text-align: center;
+    margin-bottom: 1.5rem;
+}
+
+.taskip-legal-card-icon-container {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 80px;
+    height: 80px;
+    border-radius: 16px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+.taskip-legal-card-custom-icon,
+.taskip-legal-card-default-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+}
+
+.taskip-legal-card-custom-icon svg,
+.taskip-legal-card-default-icon svg {
+    width: 48px;
+    height: 48px;
+    fill: currentColor;
+    stroke: currentColor;
+}
+
+/* Legacy styles for backward compatibility */
+.taskip-legal-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 12px;
+    object-fit: cover;
+}
+
+.taskip-legal-default-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 12px;
+    color: #fff;
+}
+
+.taskip-legal-card-content {
+    flex-grow: 1;
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+.taskip-legal-card-title {
+    font-size: 1.45rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    line-height: 1.4;
+}
+
+.taskip-legal-card-link {
+    color: #1a1a1a;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.taskip-legal-card-link:hover {
+    color: var(--color-2);
+}
+
+.taskip-legal-card-excerpt {
+    color: #666;
+    line-height: 1.6;
+    margin-bottom: 1rem;
+}
+
+.taskip-legal-card-meta {
+    font-size: 0.875rem;
+    color: #888;
+    margin-bottom: 1rem;
+}
+
+.updated-label {
+    font-weight: 600;
+}
+
+.taskip-legal-card-footer {
+    margin-top: auto;
+    text-align: center;
+    border-top: 1px solid #f0f0f0;
+    padding-top: 1.5rem;
+}
+
+.taskip-legal-card-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    color: #363636;
+    text-decoration: none;
+    border-radius: 8px;
+    font-weight: 500;
+    transition: all 0.3s ease;
+    border: 1px solid #e2e2e2;
+}
+
+.taskip-legal-card-button:hover {
+    background: var(--color-2);
+    color: #fff;
+    border: 1px solid var(--color-2);
+    transform: translateY(-1px);
+}
+
+.taskip-legal-card-button svg {
+    transition: transform 0.3s ease;
+}
+
+.taskip-legal-card-button:hover svg {
+    transform: translateX(2px);
+}
+
+.taskip-legal-no-content {
+    text-align: center;
+    padding: 3rem 2rem;
+    background: #fff;
+    border-radius: 12px;
+    color: #666;
+    font-size: 1.125rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+}
+
+/* Legal Single Page */
+.taskip-legal-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem 20px;
+}
+
+.taskip-legal-wrapper {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 3rem;
+    align-items: start;
+    padding-top: 120px;
+}
+
+/* Legal Sidebar Navigation */
+.taskip-legal-sidebar {
+    position: sticky;
+    top: 2rem;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+    padding: 1.5rem;
+    margin-top: 50px;
+}
+
+.taskip-legal-nav-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    margin: 0 0 1rem 0;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #f0f0f0;
+}
+
+.taskip-legal-nav-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.taskip-legal-nav-item {
+    margin-bottom: 0.25rem;
+}
+
+.taskip-legal-nav-link {
+    display: block;
+    padding: 0.75rem 1rem;
+    color: #666;
+    text-decoration: none;
+    border-radius: 8px;
+    font-weight: 500;
+    transition: all 0.3s ease;
+    border: 2px solid transparent;
+}
+
+.taskip-legal-nav-link:hover {
+    background: #f8f9fa;
+    color: var(--color-2);
+}
+
+.taskip-legal-nav-link.current {
+    background: var(--color-2);
+    color: #fff;
+}
+
+/* Legal Main Content */
+.taskip-legal-main {
+    background: #fff;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+/* Legal Hero Section */
+.taskip-legal-hero {
+    background: #ffffff;
+    padding: 2rem 2rem;
+    box-shadow: 0 10px 30px rgba(16, 30, 54, .05);
+    margin: 1rem;
+    border-radius: 10px;
+    margin-top: 50px;
+}
+
+.taskip-legal-hero-content {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    max-width: none;
+    position: relative;
+}
+
+
+.taskip-legal-hero-icon-container {
+    flex-shrink: 0;
+    width: 80px;
+    height: 80px;
+    border-radius: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #4ECDC4 0%, #44A08D 100%);
+    box-shadow: 0 4px 15px rgba(78, 205, 196, 0.3);
+    position: absolute;
+    right: 10px;
+    top: -70px;
+}
+
+.taskip-legal-hero-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+}
+
+.taskip-legal-hero-icon svg {
+    width: 48px;
+    height: 48px;
+    fill: currentColor;
+    stroke: currentColor;
+}
+
+.taskip-legal-hero-text {
+    flex: 1;
+}
+
+.taskip-legal-hero-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin: 0 0 1rem 0;
+    line-height: 1.2;
+}
+
+.taskip-legal-hero-description {
+    font-size: 1.125rem;
+    color: #666;
+    line-height: 1.6;
+    margin: 0;
+}
+
+.taskip-legal-article {
+    padding: 3rem 2rem;
+}
+
+.taskip-legal-content {
+    font-size: 1rem;
+    line-height: 1.8;
+    color: #444;
+}
+
+.taskip-legal-content h2 {
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    margin: 2.5rem 0 1rem 0;
+    line-height: 1.3;
+}
+
+.taskip-legal-content h3 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    margin: 2rem 0 1rem 0;
+    line-height: 1.4;
+}
+
+.taskip-legal-content h4 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    margin: 1.5rem 0 0.75rem 0;
+    line-height: 1.4;
+}
+
+.taskip-legal-content p {
+    margin-bottom: 1.25rem;
+}
+
+.taskip-legal-content ul,
+.taskip-legal-content ol {
+    margin-bottom: 1.25rem;
+    padding-left: 1.5rem;
+}
+
+.taskip-legal-content li {
+    margin-bottom: 0.5rem;
+}
+
+.taskip-legal-content a {
+    color: #667eea;
+    text-decoration: underline;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.taskip-legal-content a:hover {
+    color: #5a6fd8;
+}
+
+.taskip-legal-content blockquote {
+    background: #f8f9fa;
+    border-left: 4px solid #667eea;
+    padding: 1.5rem;
+    margin: 2rem 0;
+    border-radius: 0 8px 8px 0;
+    font-style: italic;
+}
+
+.taskip-legal-content code {
+    background: #f1f3f4;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    font-family: 'Monaco', 'Courier New', monospace;
+    font-size: 0.875rem;
+}
+
+.taskip-legal-content pre {
+    background: #f8f9fa;
+    padding: 1.5rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+}
+
+.taskip-legal-content table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+    background: #fff;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.taskip-legal-content th,
+.taskip-legal-content td {
+    padding: 1rem;
+    text-align: left;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.taskip-legal-content th {
+    background: #f8f9fa;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+
+.taskip-legal-footer {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 2px solid #f0f0f0;
+    text-align: center;
+}
+
+.taskip-legal-updated,
+.taskip-legal-published {
+    margin: 0;
+    font-size: 0.875rem;
+    color: #666;
+}
+
+.taskip-legal-updated strong,
+.taskip-legal-published strong {
+    color: #1a1a1a;
+}
+
+/* Page Links */
+.page-links {
+    margin: 2rem 0;
+    text-align: center;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+}
+
+.page-links a {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    margin: 0 0.25rem;
+    background: #667eea;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: background 0.3s ease;
+}
+
+.page-links a:hover {
+    background: #5a6fd8;
+}
+
+/* Responsive Styles for Legal Pages */
+@media (max-width: 1024px) {
+    .taskip-legal-wrapper {
+        grid-template-columns: 240px 1fr;
+        gap: 2rem;
+    }
+    
+    .taskip-legal-sidebar {
+        padding: 1.25rem;
+    }
+    
+    .taskip-legal-hero {
+        padding: 2.5rem 3rem;
+    }
+    
+    .taskip-legal-article {
+        padding: 2.5rem 3rem;
+    }
+}
+
+@media (max-width: 900px) {
+    .taskip-legal-archive-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1.5rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .taskip-legal-container {
+        padding: 1rem 15px;
+    }
+    
+    .taskip-legal-wrapper {
+        grid-template-columns: 1fr;
+        gap: 2rem;
+    }
+    
+    .taskip-legal-sidebar {
+        position: static;
+        order: 2;
+    }
+    
+    .taskip-legal-main {
+        order: 1;
+    }
+    
+    .taskip-legal-hero {
+        padding: 2rem 1.5rem;
+    }
+    
+    .taskip-legal-hero-content {
+        flex-direction: column;
+        text-align: center;
+        gap: 1.5rem;
+        padding: 2rem 1.5rem;
+    }
+    
+    .taskip-legal-hero-title {
+        font-size: 2rem;
+    }
+    
+    .taskip-legal-hero-description {
+        font-size: 1rem;
+    }
+    
+    .taskip-legal-article {
+        padding: 2rem 1.5rem;
+    }
+    
+    .taskip-legal-archive-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1.5rem;
+    }
+    
+    .taskip-legal-archive-title {
+        font-size: 2rem;
+    }
+    
+    .taskip-legal-card {
+        padding: 1.5rem;
+    }
+    
+    .taskip-legal-nav-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+    
+    .taskip-legal-nav-item {
+        margin-bottom: 0;
+    }
+    
+    .taskip-legal-nav-link {
+        padding: 0.5rem 1rem;
+        font-size: 0.875rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .taskip-legal-hero {
+        padding: 1.5rem 1rem;
+    }
+    
+    .taskip-legal-hero-icon-container {
+        width: 64px;
+        height: 64px;
+        border-radius: 12px;
+        position: initial;
+    }
+    
+    .taskip-legal-hero-icon svg {
+        width: 36px;
+        height: 36px;
+    }
+    
+    .taskip-legal-hero-title {
+        font-size: 1.75rem;
+    }
+    
+    .taskip-legal-article {
+        padding: 1.5rem 1rem;
+    }
+    
+    .taskip-legal-archive-grid {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+    
+    .taskip-legal-content h2 {
+        font-size: 1.5rem;
+    }
+    
+    .taskip-legal-content h3 {
+        font-size: 1.25rem;
+    }
+    
+    .taskip-legal-archive-title {
+        font-size: 1.75rem;
+    }
+    
+    .taskip-legal-card {
+        padding: 1.25rem;
+    }
+    
+    .taskip-legal-card-icon-container {
+        width: 64px;
+        height: 64px;
+        border-radius: 12px;
+    }
+    
+    .taskip-legal-card-custom-icon svg,
+    .taskip-legal-card-default-icon svg {
+        width: 36px;
+        height: 36px;
+    }
+    
+    .taskip-legal-nav-list {
+        flex-direction: column;
+    }
+    
+    .taskip-legal-nav-link {
+        text-align: center;
+    }
+}

--- a/includes/class-taskip-metaboxes.php
+++ b/includes/class-taskip-metaboxes.php
@@ -29,6 +29,7 @@ class Taskip_Metaboxes {
         add_action('add_meta_boxes', array($this, 'add_template_meta_boxes'));
         add_action('add_meta_boxes', array($this, 'add_usecases_meta_boxes'));
         add_action('add_meta_boxes', array($this, 'add_tools_meta_boxes'));
+        add_action('add_meta_boxes', array($this, 'add_legal_meta_boxes'));
 
         // Save template metadata
         add_action('save_post', array($this, 'save_template_meta'));
@@ -69,6 +70,20 @@ class Taskip_Metaboxes {
             __('Tool Details', 'taskip-templates'),
             array($this, 'render_tools_meta_box'),
             'tools',
+            'normal',
+            'high'
+        );
+    }
+
+    /**
+     * Add meta boxes for legal page metadata
+     */
+    public function add_legal_meta_boxes() {
+        add_meta_box(
+            'taskip_legal_meta',
+            __('Legal Page Details', 'taskip-templates'),
+            array($this, 'render_legal_meta_box'),
+            'legal',
             'normal',
             'high'
         );
@@ -171,6 +186,45 @@ class Taskip_Metaboxes {
         <?php
     }
 
+    /**
+     * Render legal page meta box
+     *
+     * @param WP_Post $post The post object.
+     */
+    public function render_legal_meta_box($post) {
+        // Add nonce for security
+        wp_nonce_field('taskip_legal_meta', 'taskip_legal_meta_nonce');
+
+        // Get saved metadata
+        $hero_description = get_post_meta($post->ID, '_taskip_legal_hero_description', true);
+        $hero_icon = get_post_meta($post->ID, '_taskip_legal_hero_icon', true);
+        $icon_background_color = get_post_meta($post->ID, '_taskip_legal_icon_bg_color', true);
+        
+        // Set defaults
+        $icon_background_color = !empty($icon_background_color) ? $icon_background_color : '#4ECDC4';
+        ?>
+        <div class="taskip-meta-section">
+            <div class="taskip-meta-field">
+                <label for="taskip_legal_hero_description"><?php _e('Hero Description:', 'taskip-templates'); ?></label>
+                <textarea id="taskip_legal_hero_description" name="_taskip_legal_hero_description" class="widefat" rows="3"><?php echo esc_textarea($hero_description); ?></textarea>
+                <span class="description"><?php _e('Short description that appears below the title in the hero section', 'taskip-templates'); ?></span>
+            </div>
+            
+            <div class="taskip-meta-field">
+                <label for="taskip_legal_hero_icon"><?php _e('Hero Icon (SVG Code):', 'taskip-templates'); ?></label>
+                <textarea id="taskip_legal_hero_icon" name="_taskip_legal_hero_icon" class="widefat" rows="8"><?php echo esc_textarea($hero_icon); ?></textarea>
+                <span class="description"><?php _e('Paste SVG code for the icon. Example: &lt;svg&gt;...&lt;/svg&gt;', 'taskip-templates'); ?></span>
+            </div>
+            
+            <div class="taskip-meta-field">
+                <label for="taskip_legal_icon_bg_color"><?php _e('Icon Background Color:', 'taskip-templates'); ?></label>
+                <input type="color" id="taskip_legal_icon_bg_color" name="_taskip_legal_icon_bg_color" value="<?php echo esc_attr($icon_background_color); ?>" />
+                <span class="description"><?php _e('Background color for the hero icon', 'taskip-templates'); ?></span>
+            </div>
+        </div>
+        <?php
+    }
+
 
     /**
      * Render template meta box
@@ -211,7 +265,7 @@ Used by 250+ professionals";
      */
     public function save_template_meta($post_id) {
 
-        // Add nonce check for usecases, templates, and tools
+        // Add nonce check for usecases, templates, tools, and legal
         if (isset($_POST['taskip_usecases_meta_nonce'])) {
             if (!wp_verify_nonce($_POST['taskip_usecases_meta_nonce'], 'taskip_usecases_meta')) {
                 return;
@@ -222,6 +276,10 @@ Used by 250+ professionals";
             }
         } elseif (isset($_POST['taskip_tools_meta_nonce'])) {
             if (!wp_verify_nonce($_POST['taskip_tools_meta_nonce'], 'taskip_tools_meta')) {
+                return;
+            }
+        } elseif (isset($_POST['taskip_legal_meta_nonce'])) {
+            if (!wp_verify_nonce($_POST['taskip_legal_meta_nonce'], 'taskip_legal_meta')) {
                 return;
             }
         } else {
@@ -288,6 +346,69 @@ Used by 250+ professionals";
             }
             if (isset($_POST['_taskip_tool_gradient_end'])) {
                 update_post_meta($post_id, '_taskip_tool_gradient_end', sanitize_hex_color($_POST['_taskip_tool_gradient_end']));
+            }
+        } elseif ($_POST['post_type'] === 'legal') {
+            if (!current_user_can('edit_post', $post_id)) {
+                return;
+            }
+
+            // Save legal page metadata
+            if (isset($_POST['_taskip_legal_hero_description'])) {
+                update_post_meta($post_id, '_taskip_legal_hero_description', sanitize_textarea_field($_POST['_taskip_legal_hero_description']));
+            }
+            if (isset($_POST['_taskip_legal_hero_icon'])) {
+                update_post_meta($post_id, '_taskip_legal_hero_icon', wp_kses($_POST['_taskip_legal_hero_icon'], array(
+                    'svg' => array(
+                        'class' => array(),
+                        'aria-hidden' => array(),
+                        'aria-labelledby' => array(),
+                        'role' => array(),
+                        'xmlns' => array(),
+                        'width' => array(),
+                        'height' => array(),
+                        'viewbox' => array(),
+                        'fill' => array(),
+                        'stroke' => array(),
+                        'stroke-width' => array(),
+                        'stroke-linecap' => array(),
+                        'stroke-linejoin' => array(),
+                    ),
+                    'path' => array(
+                        'd' => array(),
+                        'fill' => array(),
+                        'stroke' => array(),
+                        'stroke-width' => array(),
+                        'stroke-linecap' => array(),
+                        'stroke-linejoin' => array(),
+                    ),
+                    'circle' => array(
+                        'cx' => array(),
+                        'cy' => array(),
+                        'r' => array(),
+                        'fill' => array(),
+                        'stroke' => array(),
+                        'stroke-width' => array(),
+                    ),
+                    'rect' => array(
+                        'x' => array(),
+                        'y' => array(),
+                        'width' => array(),
+                        'height' => array(),
+                        'fill' => array(),
+                        'stroke' => array(),
+                        'stroke-width' => array(),
+                        'rx' => array(),
+                        'ry' => array(),
+                    ),
+                    'g' => array(),
+                    'defs' => array(),
+                    'clippath' => array(
+                        'id' => array(),
+                    ),
+                )));
+            }
+            if (isset($_POST['_taskip_legal_icon_bg_color'])) {
+                update_post_meta($post_id, '_taskip_legal_icon_bg_color', sanitize_hex_color($_POST['_taskip_legal_icon_bg_color']));
             }
         }
 

--- a/includes/class-taskip-post-types.php
+++ b/includes/class-taskip-post-types.php
@@ -182,6 +182,55 @@ class Taskip_Post_Types {
 
         register_post_type('tools', $tools_args);
 
+        // Register Legal post type
+        $legal_labels = array(
+            'name'               => _x('Legal Pages', 'post type general name', 'taskip-templates'),
+            'singular_name'      => _x('Legal Page', 'post type singular name', 'taskip-templates'),
+            'menu_name'          => _x('Legal', 'admin menu', 'taskip-templates'),
+            'name_admin_bar'     => _x('Legal Page', 'add new on admin bar', 'taskip-templates'),
+            'add_new'            => _x('Add New', 'legal page', 'taskip-templates'),
+            'add_new_item'       => __('Add New Legal Page', 'taskip-templates'),
+            'new_item'           => __('New Legal Page', 'taskip-templates'),
+            'edit_item'          => __('Edit Legal Page', 'taskip-templates'),
+            'view_item'          => __('View Legal Page', 'taskip-templates'),
+            'all_items'          => __('All Legal Pages', 'taskip-templates'),
+            'search_items'       => __('Search Legal Pages', 'taskip-templates'),
+            'parent_item_colon'  => __('Parent Legal Pages:', 'taskip-templates'),
+            'not_found'          => __('No legal pages found.', 'taskip-templates'),
+            'not_found_in_trash' => __('No legal pages found in Trash.', 'taskip-templates')
+        );
+
+        $legal_args = array(
+            'labels'             => $legal_labels,
+            'description'        => __('Legal pages like Terms of Service, Privacy Policy, etc.', 'taskip-templates'),
+            'public'             => true,
+            'publicly_queryable' => true,
+            'show_ui'            => true,
+            'show_in_menu'       => true,
+            'query_var'          => true,
+            'rewrite'            => array('slug' => 'legal'),
+            'capability_type'    => 'page',
+            'has_archive'        => true,
+            'hierarchical'       => true,
+            'menu_position'      => null,
+            'menu_icon'          => 'dashicons-admin-page',
+            'supports'           => array(
+                'title',
+                'editor',
+                'author',
+                'thumbnail',
+                'excerpt',
+                'comments',
+                'custom-fields',
+                'revisions',
+                'page-attributes',
+                'block-templates'
+            ),
+            'show_in_rest'       => true,
+        );
+
+        register_post_type('legal', $legal_args);
+
     }
 
     /**
@@ -189,7 +238,7 @@ class Taskip_Post_Types {
      */
     public function enqueue_block_editor_assets() {
         // Only enqueue for our custom post types
-        $allowed_post_types = array('taskip_template', 'taskip_usecases', 'tools');
+        $allowed_post_types = array('taskip_template', 'taskip_usecases', 'tools', 'legal');
         if (!in_array(get_post_type(), $allowed_post_types)) {
             return;
         }
@@ -200,7 +249,7 @@ class Taskip_Post_Types {
      * Ensure block editor is enabled for our post type
      */
     public function enable_block_editor($can_edit, $post_type) {
-        $allowed_post_types = array('taskip_template', 'taskip_usecases', 'tools');
+        $allowed_post_types = array('taskip_template', 'taskip_usecases', 'tools', 'legal');
         if (in_array($post_type, $allowed_post_types)) {
             return true; // Force enable block editor for our post types
         }

--- a/includes/class-taskip-templates.php
+++ b/includes/class-taskip-templates.php
@@ -68,8 +68,10 @@ class Taskip_Templates {
         // Only enqueue on template pages
         if (is_post_type_archive('taskip_template') ||
             is_post_type_archive('tools') ||
+            is_post_type_archive('legal') ||
             is_singular('taskip_template') ||
             is_singular('tools') ||
+            is_singular('legal') ||
             is_tax('template_type') ||
             is_tax('template_industry') ||
             is_page_template('templates/page-templates.php')) {
@@ -194,10 +196,14 @@ class Taskip_Templates {
             $file = 'single-taskip_template.php';
         } elseif (is_singular('tools')) {
             $file = 'single-tools.php';
+        } elseif (is_singular('legal')) {
+            $file = 'single-legal.php';
         } elseif (is_post_type_archive('taskip_template')) {
             $file = 'archive-taskip_template.php';
         } elseif (is_post_type_archive('tools')) {
             $file = 'archive-tools.php';
+        } elseif (is_post_type_archive('legal')) {
+            $file = 'archive-legal.php';
         } elseif (is_tax('template_type') || is_tax('template_industry')) {
             $file = 'taxonomy-template.php';
         }

--- a/templates/archive-legal.php
+++ b/templates/archive-legal.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Archive Legal Pages Template
+ *
+ * @package Taskip Templates Showcase
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+get_header(); ?>
+
+<div class="taskip-legal-archive">
+    <div class="taskip-legal-archive-container">
+        
+        <header class="taskip-legal-archive-header">
+            <h1 class="taskip-legal-archive-title">
+                <?php _e('Legal Pages', 'taskip-templates'); ?>
+            </h1>
+            <p class="taskip-legal-archive-description">
+                <?php _e('We are dedicated to safeguarding your data, ensuring your private information remains confidential, and maintaining transparency in all our business practices.', 'taskip-templates'); ?>
+            </p>
+        </header>
+
+        <?php if (have_posts()) : ?>
+            <div class="taskip-legal-archive-grid">
+                <?php while (have_posts()) : the_post(); ?>
+                    <?php
+                    // Get custom meta data for each legal page
+                    $hero_icon = get_post_meta(get_the_ID(), '_taskip_legal_hero_icon', true);
+                    $icon_bg_color = get_post_meta(get_the_ID(), '_taskip_legal_icon_bg_color', true);
+                    
+                    // Use default color if not set
+                    if (empty($icon_bg_color)) {
+                        $icon_bg_color = '#667eea';
+                    }
+                    ?>
+                    <article class="taskip-legal-archive-item">
+                        <div class="taskip-legal-card">
+                            
+                            <div class="taskip-legal-card-icon">
+                                <div class="taskip-legal-card-icon-container" style="background-color: <?php echo esc_attr($icon_bg_color); ?>;">
+                                    <?php if ($hero_icon) : ?>
+                                        <div class="taskip-legal-card-custom-icon">
+                                            <?php echo wp_kses($hero_icon, array(
+                                                'svg' => array(
+                                                    'class' => array(),
+                                                    'aria-hidden' => array(),
+                                                    'aria-labelledby' => array(),
+                                                    'role' => array(),
+                                                    'xmlns' => array(),
+                                                    'width' => array(),
+                                                    'height' => array(),
+                                                    'viewbox' => array(),
+                                                    'fill' => array(),
+                                                    'stroke' => array(),
+                                                    'stroke-width' => array(),
+                                                    'stroke-linecap' => array(),
+                                                    'stroke-linejoin' => array(),
+                                                ),
+                                                'path' => array(
+                                                    'd' => array(),
+                                                    'fill' => array(),
+                                                    'stroke' => array(),
+                                                    'stroke-width' => array(),
+                                                    'stroke-linecap' => array(),
+                                                    'stroke-linejoin' => array(),
+                                                ),
+                                                'circle' => array(
+                                                    'cx' => array(),
+                                                    'cy' => array(),
+                                                    'r' => array(),
+                                                    'fill' => array(),
+                                                    'stroke' => array(),
+                                                    'stroke-width' => array(),
+                                                ),
+                                                'rect' => array(
+                                                    'x' => array(),
+                                                    'y' => array(),
+                                                    'width' => array(),
+                                                    'height' => array(),
+                                                    'fill' => array(),
+                                                    'stroke' => array(),
+                                                    'stroke-width' => array(),
+                                                    'rx' => array(),
+                                                    'ry' => array(),
+                                                ),
+                                                'g' => array(),
+                                                'defs' => array(),
+                                                'clippath' => array(
+                                                    'id' => array(),
+                                                ),
+                                            )); ?>
+                                        </div>
+                                    <?php else : ?>
+                                        <div class="taskip-legal-card-default-icon">
+                                            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                <path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                                                <path d="M14 2V8H20" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                                                <path d="M16 13H8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                                <path d="M16 17H8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                                <path d="M10 9H9H8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+
+                            <div class="taskip-legal-card-content">
+                                <h2 class="taskip-legal-card-title">
+                                    <a href="<?php the_permalink(); ?>" class="taskip-legal-card-link">
+                                        <?php the_title(); ?>
+                                    </a>
+                                </h2>
+                                
+                                <?php if (get_the_excerpt()) : ?>
+                                    <p class="taskip-legal-card-excerpt">
+                                        <?php echo wp_trim_words(get_the_excerpt(), 20); ?>
+                                    </p>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="taskip-legal-card-footer">
+                                <a href="<?php the_permalink(); ?>" class="taskip-legal-card-button">
+                                    <?php _e('Read More', 'taskip-templates'); ?>
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M5 12H19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                        <path d="M12 5L19 12L12 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                    </svg>
+                                </a>
+                            </div>
+
+                        </div>
+                    </article>
+                <?php endwhile; ?>
+            </div>
+
+            <?php
+            // Pagination
+            the_posts_pagination(array(
+                'prev_text' => __('Previous', 'taskip-templates'),
+                'next_text' => __('Next', 'taskip-templates'),
+            ));
+            ?>
+
+        <?php else : ?>
+            <div class="taskip-legal-no-content">
+                <p><?php _e('No legal pages found.', 'taskip-templates'); ?></p>
+            </div>
+        <?php endif; ?>
+
+    </div>
+</div>
+
+<?php get_footer(); ?>

--- a/templates/single-legal.php
+++ b/templates/single-legal.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Single Legal Page Template
+ *
+ * @package Taskip Templates Showcase
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+get_header(); ?>
+
+<div class="taskip-legal-container">
+    <div class="taskip-legal-wrapper">
+        
+        <!-- Left Sidebar Navigation -->
+        <aside class="taskip-legal-sidebar">
+            <nav class="taskip-legal-nav">
+                <h3 class="taskip-legal-nav-title"><?php _e('Pages', 'taskip-templates'); ?></h3>
+                <ul class="taskip-legal-nav-list">
+                    <?php
+                    // Get all legal pages
+                    $legal_pages = get_posts(array(
+                        'post_type' => 'legal',
+                        'posts_per_page' => -1,
+                        'post_status' => 'publish',
+                        'orderby' => 'menu_order',
+                        'order' => 'ASC'
+                    ));
+
+                    if ($legal_pages) :
+                        foreach ($legal_pages as $legal_page) :
+                            $is_current = (get_the_ID() === $legal_page->ID) ? 'current' : '';
+                            ?>
+                            <li class="taskip-legal-nav-item <?php echo $is_current; ?>">
+                                <a href="<?php echo get_permalink($legal_page->ID); ?>" 
+                                   class="taskip-legal-nav-link <?php echo $is_current; ?>">
+                                    <?php echo esc_html($legal_page->post_title); ?>
+                                </a>
+                            </li>
+                            <?php
+                        endforeach;
+                    endif;
+                    ?>
+                </ul>
+            </nav>
+        </aside>
+
+        <!-- Main Content Area -->
+        <main class="taskip-legal-main">
+            <?php while (have_posts()) : the_post(); ?>
+                <?php
+                // Get custom meta data
+                $hero_description = get_post_meta(get_the_ID(), '_taskip_legal_hero_description', true);
+                $hero_icon = get_post_meta(get_the_ID(), '_taskip_legal_hero_icon', true);
+                $icon_bg_color = get_post_meta(get_the_ID(), '_taskip_legal_icon_bg_color', true);
+                
+                // Use defaults if not set
+                if (empty($icon_bg_color)) {
+                    $icon_bg_color = '#4ECDC4';
+                }
+                ?>
+                
+                <!-- Hero Section -->
+                <section class="taskip-legal-hero">
+                    <div class="taskip-legal-hero-content">
+                        <div class="taskip-legal-hero-icon-container" style="background-color: <?php echo esc_attr($icon_bg_color); ?>;">
+                            <?php if ($hero_icon) : ?>
+                                <div class="taskip-legal-hero-icon">
+                                    <?php echo wp_kses($hero_icon, array(
+                                        'svg' => array(
+                                            'class' => array(),
+                                            'aria-hidden' => array(),
+                                            'aria-labelledby' => array(),
+                                            'role' => array(),
+                                            'xmlns' => array(),
+                                            'width' => array(),
+                                            'height' => array(),
+                                            'viewbox' => array(),
+                                            'fill' => array(),
+                                            'stroke' => array(),
+                                            'stroke-width' => array(),
+                                            'stroke-linecap' => array(),
+                                            'stroke-linejoin' => array(),
+                                        ),
+                                        'path' => array(
+                                            'd' => array(),
+                                            'fill' => array(),
+                                            'stroke' => array(),
+                                            'stroke-width' => array(),
+                                            'stroke-linecap' => array(),
+                                            'stroke-linejoin' => array(),
+                                        ),
+                                        'circle' => array(
+                                            'cx' => array(),
+                                            'cy' => array(),
+                                            'r' => array(),
+                                            'fill' => array(),
+                                            'stroke' => array(),
+                                            'stroke-width' => array(),
+                                        ),
+                                        'rect' => array(
+                                            'x' => array(),
+                                            'y' => array(),
+                                            'width' => array(),
+                                            'height' => array(),
+                                            'fill' => array(),
+                                            'stroke' => array(),
+                                            'stroke-width' => array(),
+                                            'rx' => array(),
+                                            'ry' => array(),
+                                        ),
+                                        'g' => array(),
+                                        'defs' => array(),
+                                        'clippath' => array(
+                                            'id' => array(),
+                                        ),
+                                    )); ?>
+                                </div>
+                            <?php else : ?>
+                                <!-- Default document icon if no custom icon is set -->
+                                <div class="taskip-legal-hero-icon">
+                                    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                                        <path d="M14 2V8H20" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                                        <path d="M16 13H8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                        <path d="M16 17H8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                        <path d="M10 9H9H8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                    </svg>
+                                </div>
+                            <?php endif; ?>
+                        </div>
+                        
+                        <div class="taskip-legal-hero-text">
+                            <h1 class="taskip-legal-hero-title"><?php the_title(); ?></h1>
+                            <?php if ($hero_description) : ?>
+                                <p class="taskip-legal-hero-description">
+                                    <?php echo esc_html($hero_description); ?>
+                                </p>
+                            <?php elseif (get_the_excerpt()) : ?>
+                                <p class="taskip-legal-hero-description">
+                                    <?php echo get_the_excerpt(); ?>
+                                </p>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </section>
+
+                <article id="post-<?php the_ID(); ?>" <?php post_class('taskip-legal-article'); ?>>
+
+                    <div class="taskip-legal-content">
+                        <?php the_content(); ?>
+                    </div>
+
+                </article>
+            <?php endwhile; ?>
+        </main>
+
+    </div>
+</div>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
- Add new 'legal' post type with hierarchical structure
- Create custom metaboxes for hero description, SVG icons, and background colors
- Implement hero sections with customizable icons and descriptions
- Build responsive 3-column archive grid that adapts to mobile
- Add left sidebar navigation for single legal pages
- Include consistent default document icons when no custom SVG provided
- Support custom background colors for icons via metadata
- Add comprehensive responsive design for all screen sizes
- Integrate with existing plugin structure and template loading